### PR TITLE
fix(web): v1.0.1 — CSP frame-src で ALU 埋め込みを許可 + ヒーローキャッチ微修正

### DIFF
--- a/apps/web/public/og.svg
+++ b/apps/web/public/og.svg
@@ -28,10 +28,10 @@
 
   <!-- キャッチコピー -->
   <text x="80" y="360" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="36" fill="#f5f5f5" font-weight="600">
-    内製開発で 10 年以上よいソフトウェアを探求し続けている
+    内製開発 10 数年、よいソフトウェアを探求せし
   </text>
   <text x="80" y="410" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="36" fill="#f5f5f5" font-weight="600">
-    絶滅危惧種 XPer
+    達人プログラマーになりたかった絶滅危惧種 XP おじさん
   </text>
 
   <!-- 得意領域タグ -->

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -57,6 +57,7 @@ if (basicAuthUser && basicAuthPass) {
 // セキュリティヘッダ
 // - HSTS は Cloudflare 側で付与するため Express 側は無効化
 // - CSP は Astro Islands の inline script を許可
+// - frame-src: ALU 公式コマ埋め込み（https://alu.jp）を許可
 app.use(
   helmet({
     strictTransportSecurity: false,
@@ -68,6 +69,7 @@ app.use(
         "img-src": ["'self'", "data:", "https:"],
         "font-src": ["'self'"],
         "connect-src": ["'self'"],
+        "frame-src": ["'self'", "https://alu.jp"],
         "frame-ancestors": ["'none'"],
         "base-uri": ["'self'"],
         "form-action": ["'self'"],
@@ -117,14 +119,14 @@ app.use((_req, res) => {
 });
 
 const server = app.listen(port, () => {
-  // eslint-disable-next-line no-console
+   
   console.log(`listening on ${port}`);
 });
 
 // Graceful shutdown
 /** @param {NodeJS.Signals} signal */
 const shutdown = (signal) => {
-  // eslint-disable-next-line no-console
+   
   console.log(`${signal} received, shutting down`);
   server.close(() => {
     process.exit(0);

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -119,14 +119,12 @@ app.use((_req, res) => {
 });
 
 const server = app.listen(port, () => {
-   
   console.log(`listening on ${port}`);
 });
 
 // Graceful shutdown
 /** @param {NodeJS.Signals} signal */
 const shutdown = (signal) => {
-   
   console.log(`${signal} received, shutting down`);
   server.close(() => {
     process.exit(0);

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -8,7 +8,8 @@ type Skill = CollectionEntry<"skills">;
 const profile = {
   name: "k2works",
   role: "Software Engineer",
-  catchCopy: "内製開発 10 数年、よいソフトウェアを探求せし \n絶滅危惧種 XP おじさん",
+  catchCopy:
+    "内製開発 10 数年、よいソフトウェアを探求せし \n達人プログラマーになりたかった絶滅危惧種 XP おじさん",
   catchLink: {
     href: "https://alu.jp/series/%E3%83%99%E3%83%AB%E3%82%BB%E3%83%AB%E3%82%AF/crop/0bTcJtFIwaKRapCLxFHY",
     label: "ブログで使えるベルセルクのコマ（ALU）",


### PR DESCRIPTION
## Summary

- v1.0.0 リリース後、staging で ALU 公式コマ埋め込み（ヒーロー領域）が CSP `default-src: 'self'` のフォールバックで blocked となる問題を修正。
- 併せて、ヒーロー直下のキャッチコピー 2 行目に「達人プログラマーになりたかった」を追記。OGP 画像（og.svg）も同期。

## Changes

- `apps/web/server.js`: helmet CSP directives に `frame-src: ['self', 'https://alu.jp']` を明示追加。`frame-ancestors: 'none'` は維持。
- `apps/web/src/pages/index.astro`: catchCopy 2 行目を「達人プログラマーになりたかった絶滅危惧種 XP おじさん」に拡張。
- `apps/web/public/og.svg`: OGP 画像のキャッチ 2 行を同期。

## Verification

- ローカル: `node apps/web/server.js` でレスポンスヘッダの Content-Security-Policy に `frame-src 'self' https://alu.jp` が含まれることを `curl -I` で確認。
- E2E: smoke + a11y + seo の 30/30 pass。
- Lighthouse v1.0 予算: 別途検証済（Perf 1.0 / SEO 1.0 / A11y 1.0 / BP 0.96）。

## Test plan

- [ ] CI（Build / Lint+Test / E2E / Security / Heroku staging deploy）pass
- [ ] staging で ALU iframe がレンダリングされる（CSP block が解消）
- [ ] main マージ後の Lighthouse CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)